### PR TITLE
Changed validation to only allow alpha-numeric names.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpr-util-validation",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Shared js utility for experiment validation",
   "main": "./index.js",
   "author": "Jason Allen <allenjt@ldschurch.org>",


### PR DESCRIPTION
# Problem space:
- Experiment names with '.', '-', or '_' characters cause the 'experiment' module dependency to throw an error.
# Changes:
- [ ] Changed experiment name validation to only allow alpha-numeric characters, where the first character must be an alpha character.  This is more compatible with the 'experiment' module dependency.
- [ ] Updated unit test to validate changes.
- [ ] Changed package.json version to 0.1.0.
# Should:
- [ ] Only allow experiment names with alpha-numeric characters.
- [ ] Only allow experiment names to begin with an alpha character.
